### PR TITLE
Add proprietary license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,5 @@
+LICENÇA DE USO RESTRITO
+
+Todos os direitos reservados. Este software é de propriedade exclusiva do desenvolvedor. Não é permitida a cópia, modificação, distribuição ou utilização deste software sem autorização prévia por escrito.
+
+Para adquirir uma licença de uso ou obter mais informações, entre em contato com o proprietário do repositório.

--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ npm run build
 You can preview the production build with `npm run preview`.
 
 > To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
+
+## Licença
+
+Este projeto é distribuído sob Licença de Uso Restrito. Consulte o arquivo [LICENSE](LICENSE) para detalhes.


### PR DESCRIPTION
## Summary
- add Portuguese proprietary licensing terms
- mention the license in the README

## Testing
- `npm run lint` *(fails: Expected token '}' and SyntaxError: Unterminated string constant)*

------
https://chatgpt.com/codex/tasks/task_e_688d2b58761c8329815d7ce08743681c