### PR TITLE
feat: force frames on mobile scrolly

### DIFF
--- a/src/lib/components/StoryRenderer.svelte
+++ b/src/lib/components/StoryRenderer.svelte
@@ -1,431 +1,446 @@
 <!-- src/lib/components/StoryRenderer.svelte -->
 <script>
-  // Importação dos componentes da história
-  import Header from './story/Header.svelte';
-  import StoryText from './story/StoryText.svelte';
-  import SectionTitle from './story/SectionTitle.svelte';
-  import SectionWrapper from './story/SectionWrapper.svelte'; // 🆕 NOVO COMPONENTE
-  import PhotoWithCaption from './story/PhotoWithCaption.svelte';
-  import VideoPlayer from './story/VideoPlayer.svelte';
-  import GloboPlayer from './story/GloboPlayer.svelte';
-  import PhotoGallery from './story/PhotoGallery.svelte';
-  import Carousel from './story/Carousel.svelte';
-  import Parallax from './story/Parallax.svelte';
-  import BeforeAfter from './story/BeforeAfter.svelte';
-  import ScrollyTelling from './story/ScrollyTelling.svelte';
-  import VideoScrollytelling from './story/VideoScrollytelling.svelte';
-  import FlourishEmbed from './story/FlourishEmbed.svelte';
-  import FlourishScrolly from './story/FlourishScrolly.svelte';
-  import FinalCredits from './FinalCredits.svelte';
-  import AnchorPoint from './story/AnchorPoint.svelte';
+	// Importação dos componentes da história
+	import Header from './story/Header.svelte';
+	import StoryText from './story/StoryText.svelte';
+	import SectionTitle from './story/SectionTitle.svelte';
+	import SectionWrapper from './story/SectionWrapper.svelte'; // 🆕 NOVO COMPONENTE
+	import PhotoWithCaption from './story/PhotoWithCaption.svelte';
+	import VideoPlayer from './story/VideoPlayer.svelte';
+	import GloboPlayer from './story/GloboPlayer.svelte';
+	import PhotoGallery from './story/PhotoGallery.svelte';
+	import Carousel from './story/Carousel.svelte';
+	import Parallax from './story/Parallax.svelte';
+	import BeforeAfter from './story/BeforeAfter.svelte';
+	import ScrollyTelling from './story/ScrollyTelling.svelte';
+	import VideoScrollytelling from './story/VideoScrollytelling.svelte';
+	import FlourishEmbed from './story/FlourishEmbed.svelte';
+	import FlourishScrolly from './story/FlourishScrolly.svelte';
+	import FinalCredits from './FinalCredits.svelte';
+	import AnchorPoint from './story/AnchorPoint.svelte';
 
-  export let storyData = {};
+	export let storyData = {};
 
-  // ✅ DEBUG: Ver o que está chegando
-  $: {
-    console.log('=== DEBUG STORYDATA ===');
-    console.log('storyData:', storyData);
-    console.log('paragraphs:', storyData.paragraphs);
-    if (storyData.paragraphs) {
-      storyData.paragraphs.forEach((p, i) => {
-        console.log(`Paragraph ${i}:`, p.type, p);
-      });
-    }
-    console.log('========================');
-  }
+	// ✅ DEBUG: Ver o que está chegando
+	$: {
+		console.log('=== DEBUG STORYDATA ===');
+		console.log('storyData:', storyData);
+		console.log('paragraphs:', storyData.paragraphs);
+		if (storyData.paragraphs) {
+			storyData.paragraphs.forEach((p, i) => {
+				console.log(`Paragraph ${i}:`, p.type, p);
+			});
+		}
+		console.log('========================');
+	}
 
-  /**
-   * Mapeia os tipos de parágrafo para os nomes dos componentes.
-   */
-  function getComponentType(paragraph) {
-    const type = paragraph.type?.toLowerCase().trim();
-    
-    console.log('🔍 Debug StoryRenderer:', { originalType: paragraph.type, normalizedType: type });
-    
-    switch (type) {
-      case 'header':
-      case 'titulo-principal':
-      case 'tituloprincipal':
-      case 'abre':
-        return 'header';
-      case 'texto':
-      case 'paragrafo':
-        return 'text';
-      case 'intertitulo':
-      case 'titulo':
-        return 'section-title';
-      case 'section': // 🆕 NOVO TIPO
-      case 'secao':
-      case 'section-wrapper':
-      case 'wrapper':
-        return 'section-wrapper';
-      case 'frase':
-      case 'citacao':
-      case 'quote':
-        return 'quote';
-      case 'foto':
-      case 'imagem':
-        return 'photo';
-      case 'video':
-      case 'mp4':
-        return 'video';
-      case 'globovideo':
-      case 'globo-video':
-      case 'globoplayer':
-      case 'globo-player':
-      case 'globo':
-        return 'globo-player';
-      case 'galeria':
-      case 'gallery':
-        return 'gallery';
-      case 'carrossel':
-      case 'carousel':
-        return 'carousel';
-      case 'parallax':
-        return 'parallax';
-      case 'antes-depois':
-      case 'before-after':
-        return 'before-after';
-      case 'scrollytelling':
-      case 'scrolly':
-        return 'scrolly';
-      case 'videoscrollytelling':
-      case 'video-scrollytelling':
-      case 'videoscrolly':
-      case 'video-scrolly':
-        return 'video-scrolly';
-      case 'flourish':
-      case 'flourish-embed':
-      case 'grafico':
-      case 'mapa':
-        return 'flourish';
-      case 'flourish-scrolly':
-      case 'flourish-story':
-        return 'flourish-scrolly';
-      case 'ancora':
-      case 'anchor':
-        return 'anchor';
-      default:
-        return 'text';
-    }
-  }
+	/**
+	 * Mapeia os tipos de parágrafo para os nomes dos componentes.
+	 */
+	function getComponentType(paragraph) {
+		const type = paragraph.type?.toLowerCase().trim();
 
-  /**
-   * Converte uma string (vinda do JSON) para um booleano de forma segura.
-   */
-  function stringToBoolean(value, defaultValue = false) {
-    if (typeof value === 'boolean') return value;
-    if (typeof value === 'string') {
-      const normalized = value.toLowerCase().trim();
-      return normalized === 'true' || normalized === 'yes' || normalized === 'sim' || normalized === '1';
-    }
-    return defaultValue;
-  }
+		console.log('🔍 Debug StoryRenderer:', { originalType: paragraph.type, normalizedType: type });
 
-  /**
-   * Prepara as propriedades de um parágrafo para serem passadas ao componente.
-   */
-  function prepareProps(paragraph) {
-    const props = { ...paragraph };
-    
-    // Converter strings para booleanos onde necessário
-    const booleanFields = [
-      'fullWidth', 'autoplay', 'controls', 'loop', 'showCaption', 'autoPlay',
-      'overlay', 'lightbox', 'masonry', 'showControls', 'showProgress', 'showTime',
-      'smoothTransition', 'lazyLoading', 'skipDFP', 'chromeless', 'startMuted'
-    ];
-    
-    booleanFields.forEach(field => {
-      if (props[field] !== undefined) {
-        props[field] = stringToBoolean(props[field]);
-      }
-    });
+		switch (type) {
+			case 'header':
+			case 'titulo-principal':
+			case 'tituloprincipal':
+			case 'abre':
+				return 'header';
+			case 'texto':
+			case 'paragrafo':
+				return 'text';
+			case 'intertitulo':
+			case 'titulo':
+				return 'section-title';
+			case 'section': // 🆕 NOVO TIPO
+			case 'secao':
+			case 'section-wrapper':
+			case 'wrapper':
+				return 'section-wrapper';
+			case 'frase':
+			case 'citacao':
+			case 'quote':
+				return 'quote';
+			case 'foto':
+			case 'imagem':
+				return 'photo';
+			case 'video':
+			case 'mp4':
+				return 'video';
+			case 'globovideo':
+			case 'globo-video':
+			case 'globoplayer':
+			case 'globo-player':
+			case 'globo':
+				return 'globo-player';
+			case 'galeria':
+			case 'gallery':
+				return 'gallery';
+			case 'carrossel':
+			case 'carousel':
+				return 'carousel';
+			case 'parallax':
+				return 'parallax';
+			case 'antes-depois':
+			case 'before-after':
+				return 'before-after';
+			case 'scrollytelling':
+			case 'scrolly':
+				return 'scrolly';
+			case 'videoscrollytelling':
+			case 'video-scrollytelling':
+			case 'videoscrolly':
+			case 'video-scrolly':
+				return 'video-scrolly';
+			case 'flourish':
+			case 'flourish-embed':
+			case 'grafico':
+			case 'mapa':
+				return 'flourish';
+			case 'flourish-scrolly':
+			case 'flourish-story':
+				return 'flourish-scrolly';
+			case 'ancora':
+			case 'anchor':
+				return 'anchor';
+			default:
+				return 'text';
+		}
+	}
 
-    // 🆕 Converter strings para números onde necessário
-    const numberFields = [
-      'columns', 'interval', 'speed', 'totalFrames', 'preloadFrames', 'bufferSize'
-    ];
-    
-    numberFields.forEach(field => {
-      if (props[field] !== undefined && !isNaN(props[field])) {
-        props[field] = parseFloat(props[field]);
-      }
-    });
+	/**
+	 * Converte uma string (vinda do JSON) para um booleano de forma segura.
+	 */
+	function stringToBoolean(value, defaultValue = false) {
+		if (typeof value === 'boolean') return value;
+		if (typeof value === 'string') {
+			const normalized = value.toLowerCase().trim();
+			return (
+				normalized === 'true' || normalized === 'yes' || normalized === 'sim' || normalized === '1'
+			);
+		}
+		return defaultValue;
+	}
 
-    return props;
-  }
+	/**
+	 * Prepara as propriedades de um parágrafo para serem passadas ao componente.
+	 */
+	function prepareProps(paragraph) {
+		const props = { ...paragraph };
+
+		// Converter strings para booleanos onde necessário
+		const booleanFields = [
+			'fullWidth',
+			'autoplay',
+			'controls',
+			'loop',
+			'showCaption',
+			'autoPlay',
+			'overlay',
+			'lightbox',
+			'masonry',
+			'showControls',
+			'showProgress',
+			'showTime',
+			'smoothTransition',
+			'lazyLoading',
+			'skipDFP',
+			'chromeless',
+			'startMuted'
+		];
+
+		booleanFields.forEach((field) => {
+			if (props[field] !== undefined) {
+				props[field] = stringToBoolean(props[field]);
+			}
+		});
+
+		// 🆕 Converter strings para números onde necessário
+		const numberFields = [
+			'columns',
+			'interval',
+			'speed',
+			'totalFrames',
+			'preloadFrames',
+			'bufferSize'
+		];
+
+		numberFields.forEach((field) => {
+			if (props[field] !== undefined && !isNaN(props[field])) {
+				props[field] = parseFloat(props[field]);
+			}
+		});
+
+		return props;
+	}
 </script>
 
 <article class="story-content" data-theme={storyData.theme || 'default'}>
-  <!-- Renderizar o header se tiver -->
-  {#if storyData.title || storyData.subtitle}
-    <Header
-      title={storyData.title}
-      subtitle={storyData.subtitle}
-      author={storyData.author}
-      publishDate={storyData.publishDate || storyData.date}
-      backgroundImage={storyData.backgroundImage}
-      backgroundImageMobile={storyData.backgroundImageMobile}
-      backgroundVideo={storyData.backgroundVideo}
-      backgroundVideoMobile={storyData.backgroundVideoMobile}
-      variant={storyData.variant || 'default'}
-      overlay={stringToBoolean(storyData.overlay, true)}
-    />
-  {/if}
+	<!-- Renderizar o header se tiver -->
+	{#if storyData.title || storyData.subtitle}
+		<Header
+			title={storyData.title}
+			subtitle={storyData.subtitle}
+			author={storyData.author}
+			publishDate={storyData.publishDate || storyData.date}
+			backgroundImage={storyData.backgroundImage}
+			backgroundImageMobile={storyData.backgroundImageMobile}
+			backgroundVideo={storyData.backgroundVideo}
+			backgroundVideoMobile={storyData.backgroundVideoMobile}
+			variant={storyData.variant || 'default'}
+			overlay={stringToBoolean(storyData.overlay, true)}
+		/>
+	{/if}
 
-  <!-- Renderizar intro se existir -->
-  {#if storyData.intro && storyData.intro.text}
-    <StoryText content={storyData.intro.text} variant="lead" />
-  {/if}
+	<!-- Renderizar intro se existir -->
+	{#if storyData.intro && storyData.intro.text}
+		<StoryText content={storyData.intro.text} variant="lead" />
+	{/if}
 
-  <!-- Renderizar parágrafos -->
-  {#if storyData.paragraphs && Array.isArray(storyData.paragraphs)}
-    {#each storyData.paragraphs as paragraph, index}
-      {@const componentType = getComponentType(paragraph)}
-      {@const props = prepareProps(paragraph)}
-      
-      <!-- Header -->
-      {#if componentType === 'header'}
-        <Header
-          title={props.title}
-          subtitle={props.subtitle}
-          author={props.author}
-          publishDate={props.publishDate || props.date}
-          backgroundImage={props.backgroundImage}
-          backgroundImageMobile={props.backgroundImageMobile}
-          backgroundVideo={props.backgroundVideo}
-          backgroundVideoMobile={props.backgroundVideoMobile}
-          variant={props.variant || 'default'}
-          overlay={stringToBoolean(props.overlay, true)}
-        />
+	<!-- Renderizar parágrafos -->
+	{#if storyData.paragraphs && Array.isArray(storyData.paragraphs)}
+		{#each storyData.paragraphs as paragraph, index}
+			{@const componentType = getComponentType(paragraph)}
+			{@const props = prepareProps(paragraph)}
 
-      <!-- 🆕 SECTION WRAPPER -->
-      {:else if componentType === 'section-wrapper'}
-        <SectionWrapper
-          id={props.id}
-          backgroundImage={props.backgroundImage}
-          backgroundImageMobile={props.backgroundImageMobile}
-          backgroundPosition={props.backgroundPosition || 'center'}
-          backgroundPositionMobile={props.backgroundPositionMobile || 'center'}
-          overlay={stringToBoolean(props.overlay, false)}
-          height={props.height}
-          heightMobile={props.heightMobile}
-          padding={props.padding}
-          paddingMobile={props.paddingMobile}
-          children={props.children || []}
-        >
-          <!-- Slot para conteúdo manual se necessário -->
-          {#if props.content}
-            <div class="section-content">
-              {@html props.content}
-            </div>
-          {/if}
-        </SectionWrapper>
+			<!-- Header -->
+			{#if componentType === 'header'}
+				<Header
+					title={props.title}
+					subtitle={props.subtitle}
+					author={props.author}
+					publishDate={props.publishDate || props.date}
+					backgroundImage={props.backgroundImage}
+					backgroundImageMobile={props.backgroundImageMobile}
+					backgroundVideo={props.backgroundVideo}
+					backgroundVideoMobile={props.backgroundVideoMobile}
+					variant={props.variant || 'default'}
+					overlay={stringToBoolean(props.overlay, true)}
+				/>
 
-      <!-- Text -->
-      {:else if componentType === 'text'}
-        <StoryText content={props.text} variant={props.variant || 'body'} />
+				<!-- 🆕 SECTION WRAPPER -->
+			{:else if componentType === 'section-wrapper'}
+				<SectionWrapper
+					id={props.id}
+					backgroundImage={props.backgroundImage}
+					backgroundImageMobile={props.backgroundImageMobile}
+					backgroundPosition={props.backgroundPosition || 'center'}
+					backgroundPositionMobile={props.backgroundPositionMobile || 'center'}
+					overlay={stringToBoolean(props.overlay, false)}
+					height={props.height}
+					heightMobile={props.heightMobile}
+					padding={props.padding}
+					paddingMobile={props.paddingMobile}
+					children={props.children || []}
+				>
+					<!-- Slot para conteúdo manual se necessário -->
+					{#if props.content}
+						<div class="section-content">
+							{@html props.content}
+						</div>
+					{/if}
+				</SectionWrapper>
 
-      <!-- Quote -->
-      {:else if componentType === 'quote'}
-        <StoryText
-          content={props.text}
-          variant="quote"
-          author={props.author}
-          role={props.role}
-        />
+				<!-- Text -->
+			{:else if componentType === 'text'}
+				<StoryText content={props.text} variant={props.variant || 'body'} />
 
-      <!-- Section Title -->
-      {:else if componentType === 'section-title'}
-        <SectionTitle
-          title={props.text}
-          subtitle={props.subtitle}
-          backgroundImage={props.backgroundImage}
-          backgroundImageMobile={props.backgroundImageMobile}
-          backgroundPosition={props.backgroundPosition || 'center'}
-          backgroundPositionMobile={props.backgroundPositionMobile || 'center'}
-          backgroundVideo={props.backgroundVideo}
-          backgroundVideoMobile={props.backgroundVideoMobile}
-          variant={props.variant || 'default'}
-          size={props.size || 'medium'}
-          height={props.height}
-          heightMobile={props.heightMobile}
-          textPosition={props.textPosition || 'center'}
-          textPositionMobile={props.textPositionMobile}
-          textAlign={props.textAlign || 'center'}
-          textAlignMobile={props.textAlignMobile}
-          overlay={stringToBoolean(props.overlay, false)}
-        />
+				<!-- Quote -->
+			{:else if componentType === 'quote'}
+				<StoryText content={props.text} variant="quote" author={props.author} role={props.role} />
 
-      <!-- Photo -->
-      {:else if componentType === 'photo'}
-        <PhotoWithCaption
-          src={props.src}
-          alt={props.alt || ''}
-          caption={props.caption || ''}
-          credit={props.credit || ''}
-          fullWidth={stringToBoolean(props.fullWidth, false)}
-          alignment={props.alignment || 'center'}
-        />
+				<!-- Section Title -->
+			{:else if componentType === 'section-title'}
+				<SectionTitle
+					title={props.text}
+					subtitle={props.subtitle}
+					backgroundImage={props.backgroundImage}
+					backgroundImageMobile={props.backgroundImageMobile}
+					backgroundPosition={props.backgroundPosition || 'center'}
+					backgroundPositionMobile={props.backgroundPositionMobile || 'center'}
+					backgroundVideo={props.backgroundVideo}
+					backgroundVideoMobile={props.backgroundVideoMobile}
+					variant={props.variant || 'default'}
+					size={props.size || 'medium'}
+					height={props.height}
+					heightMobile={props.heightMobile}
+					textPosition={props.textPosition || 'center'}
+					textPositionMobile={props.textPositionMobile}
+					textAlign={props.textAlign || 'center'}
+					textAlignMobile={props.textAlignMobile}
+					overlay={stringToBoolean(props.overlay, false)}
+				/>
 
-      <!-- Video -->
-      {:else if componentType === 'video'}
-        <VideoPlayer
-          src={props.src}
-          caption={props.caption}
-          credit={props.credit}
-          fullWidth={stringToBoolean(props.fullWidth, false)}
-          autoplay={stringToBoolean(props.autoplay, false)}
-          controls={stringToBoolean(props.controls, true)}
-          loop={stringToBoolean(props.loop, false)}
-          showCaption={stringToBoolean(props.showCaption, true)}
-        />
+				<!-- Photo -->
+			{:else if componentType === 'photo'}
+				<PhotoWithCaption
+					src={props.src}
+					alt={props.alt || ''}
+					caption={props.caption || ''}
+					credit={props.credit || ''}
+					fullWidth={stringToBoolean(props.fullWidth, false)}
+					alignment={props.alignment || 'center'}
+				/>
 
-      <!-- Globo Player -->
-      {:else if componentType === 'globo-player'}
-        <GloboPlayer
-          videoId={props.videoId}
-          videosIDs={props.videosIDs}
-          caption={props.caption}
-          credit={props.credit}
-          fullWidth={stringToBoolean(props.fullWidth, false)}
-          autoplay={stringToBoolean(props.autoplay, false)}
-          startMuted={stringToBoolean(props.startMuted, true)}
-          skipDFP={stringToBoolean(props.skipDFP, false)}
-          chromeless={stringToBoolean(props.chromeless, false)}
-          showCaption={stringToBoolean(props.showCaption, true)}
-        />
+				<!-- Video -->
+			{:else if componentType === 'video'}
+				<VideoPlayer
+					src={props.src}
+					caption={props.caption}
+					credit={props.credit}
+					fullWidth={stringToBoolean(props.fullWidth, false)}
+					autoplay={stringToBoolean(props.autoplay, false)}
+					controls={stringToBoolean(props.controls, true)}
+					loop={stringToBoolean(props.loop, false)}
+					showCaption={stringToBoolean(props.showCaption, true)}
+				/>
 
-      <!-- Gallery -->
-      {:else if componentType === 'gallery'}
-        <PhotoGallery
-          images={props.images || []}
-          layout={props.layout || 'grid'}
-          columns={parseInt(props.columns) || 3}
-          lightbox={stringToBoolean(props.lightbox, true)}
-        />
+				<!-- Globo Player -->
+			{:else if componentType === 'globo-player'}
+				<GloboPlayer
+					videoId={props.videoId}
+					videosIDs={props.videosIDs}
+					caption={props.caption}
+					credit={props.credit}
+					fullWidth={stringToBoolean(props.fullWidth, false)}
+					autoplay={stringToBoolean(props.autoplay, false)}
+					startMuted={stringToBoolean(props.startMuted, true)}
+					skipDFP={stringToBoolean(props.skipDFP, false)}
+					chromeless={stringToBoolean(props.chromeless, false)}
+					showCaption={stringToBoolean(props.showCaption, true)}
+				/>
 
-      <!-- Carousel -->
-      {:else if componentType === 'carousel'}
-        <Carousel
-          items={props.items || []}
-          autoplay={stringToBoolean(props.autoplay, false)}
-          interval={parseInt(props.interval) || 3000}
-          showDots={stringToBoolean(props.showDots, true)}
-          showArrows={stringToBoolean(props.showArrows, true)}
-        />
+				<!-- Gallery -->
+			{:else if componentType === 'gallery'}
+				<PhotoGallery
+					images={props.images || []}
+					layout={props.layout || 'grid'}
+					columns={parseInt(props.columns) || 3}
+					lightbox={stringToBoolean(props.lightbox, true)}
+				/>
 
-      <!-- Parallax -->
-      {:else if componentType === 'parallax'}
-        <Parallax
-          image={props.image}
-          height={props.height || '60vh'}
-          speed={parseFloat(props.speed) || 0.5}
-          overlay={stringToBoolean(props.overlay, true)}
-          content={props.content || ''}
-        />
+				<!-- Carousel -->
+			{:else if componentType === 'carousel'}
+				<Carousel
+					items={props.items || []}
+					autoplay={stringToBoolean(props.autoplay, false)}
+					interval={parseInt(props.interval) || 3000}
+					showDots={stringToBoolean(props.showDots, true)}
+					showArrows={stringToBoolean(props.showArrows, true)}
+				/>
 
-      <!-- Before/After -->
-      {:else if componentType === 'before-after'}
-        <BeforeAfter
-          beforeImage={props.beforeImage}
-          afterImage={props.afterImage}
-          beforeLabel={props.beforeLabel || 'Antes'}
-          afterLabel={props.afterLabel || 'Depois'}
-          orientation={props.orientation || 'vertical'}
-        />
+				<!-- Parallax -->
+			{:else if componentType === 'parallax'}
+				<Parallax
+					image={props.image}
+					height={props.height || '60vh'}
+					speed={parseFloat(props.speed) || 0.5}
+					overlay={stringToBoolean(props.overlay, true)}
+					content={props.content || ''}
+				/>
 
-      <!-- ScrollyTelling -->
-      {:else if componentType === 'scrolly'}
-        <ScrollyTelling
-          steps={props.steps || []}
-          fullWidth={stringToBoolean(props.fullWidth, false)}
-        />
+				<!-- Before/After -->
+			{:else if componentType === 'before-after'}
+				<BeforeAfter
+					beforeImage={props.beforeImage}
+					afterImage={props.afterImage}
+					beforeLabel={props.beforeLabel || 'Antes'}
+					afterLabel={props.afterLabel || 'Depois'}
+					orientation={props.orientation || 'vertical'}
+				/>
 
-      <!-- 🆕 VIDEO SCROLLYTELLING - VERSÃO COMPLETA E CORRIGIDA -->
-      {:else if componentType === 'video-scrolly'}
-        <VideoScrollytelling
-          videoSrc={props.videoSrc || props.src}
-          videoSrcMobile={props.videoSrcMobile || props.srcMobile}
-          steps={props.steps || []}
-          height={props.height || '300vh'}
-          fullWidth={stringToBoolean(props.fullWidth, true)}
-          showProgress={stringToBoolean(props.showProgress, true)}
-          showTime={stringToBoolean(props.showTime, true)}
-          showControls={stringToBoolean(props.showControls, false)}
-          fallbackFrames={props.fallbackFrames || []}
-          posterImage={props.posterImage || props.poster}
-          imagePrefix={props.imagePrefix || ''}
-          imagePrefixMobile={props.imagePrefixMobile || ''}
-          totalFrames={parseInt(props.totalFrames) || 0}
-          preloadFrames={parseInt(props.preloadFrames) || 5}
-          bufferSize={parseInt(props.bufferSize) || 10}
-          smoothTransition={stringToBoolean(props.smoothTransition, true)}
-          lazyLoading={stringToBoolean(props.lazyLoading, true)}
-        />
+				<!-- ScrollyTelling -->
+			{:else if componentType === 'scrolly'}
+				<ScrollyTelling
+					steps={props.steps || []}
+					fullWidth={stringToBoolean(props.fullWidth, false)}
+				/>
 
-      <!-- Flourish Embed -->
-      {:else if componentType === 'flourish'}
-        <FlourishEmbed
-          src={props.src}
-          height={props.height || '600px'}
-          caption={props.caption}
-          credit={props.credit}
-        />
+				<!-- 🆕 VIDEO SCROLLYTELLING - VERSÃO COMPLETA E CORRIGIDA -->
+			{:else if componentType === 'video-scrolly'}
+				<VideoScrollytelling
+					videoSrc={props.videoSrc || props.src}
+					videoSrcMobile={props.videoSrcMobile || props.srcMobile}
+					steps={props.steps || []}
+					height={props.height || '300vh'}
+					fullWidth={stringToBoolean(props.fullWidth, true)}
+					showProgress={stringToBoolean(props.showProgress, true)}
+					showTime={stringToBoolean(props.showTime, true)}
+					showControls={stringToBoolean(props.showControls, false)}
+					fallbackFrames={props.fallbackFrames || []}
+					posterImage={props.posterImage || props.poster}
+					imagePrefix={props.imagePrefix || ''}
+					imagePrefixMobile={props.imagePrefixMobile || ''}
+					totalFrames={parseInt(props.totalFrames) || 0}
+					preloadFrames={parseInt(props.preloadFrames) || 5}
+					bufferSize={parseInt(props.bufferSize) || 10}
+					smoothTransition={stringToBoolean(props.smoothTransition, true)}
+					lazyLoading={stringToBoolean(props.lazyLoading, true)}
+					forceFrames={stringToBoolean(props.forceFrames, false)}
+					frameDuration={parseInt(props.frameDuration) || 1000 / 30}
+				/>
 
-      <!-- Flourish Scrolly -->
-      {:else if componentType === 'flourish-scrolly'}
-        <FlourishScrolly
-          src={props.src}
-          steps={props.steps || []}
-        />
+				<!-- Flourish Embed -->
+			{:else if componentType === 'flourish'}
+				<FlourishEmbed
+					src={props.src}
+					height={props.height || '600px'}
+					caption={props.caption}
+					credit={props.credit}
+				/>
 
-      <!-- Anchor Point -->
-      {:else if componentType === 'anchor'}
-        <AnchorPoint id={props.id} />
+				<!-- Flourish Scrolly -->
+			{:else if componentType === 'flourish-scrolly'}
+				<FlourishScrolly src={props.src} steps={props.steps || []} />
 
-      <!-- Fallback para tipos desconhecidos -->
-      {:else}
-        <div class="unknown-component">
-          <p><strong>Componente desconhecido:</strong> {paragraph.type}</p>
-          <pre>{JSON.stringify(paragraph, null, 2)}</pre>
-        </div>
-      {/if}
-    {/each}
-  {/if}
+				<!-- Anchor Point -->
+			{:else if componentType === 'anchor'}
+				<AnchorPoint id={props.id} />
 
-  <!-- Renderizar créditos finais se existir -->
-  {#if storyData.credits}
-    <FinalCredits credits={storyData.credits} />
-  {/if}
+				<!-- Fallback para tipos desconhecidos -->
+			{:else}
+				<div class="unknown-component">
+					<p><strong>Componente desconhecido:</strong> {paragraph.type}</p>
+					<pre>{JSON.stringify(paragraph, null, 2)}</pre>
+				</div>
+			{/if}
+		{/each}
+	{/if}
+
+	<!-- Renderizar créditos finais se existir -->
+	{#if storyData.credits}
+		<FinalCredits credits={storyData.credits} />
+	{/if}
 </article>
 
 <style>
-  .story-content {
-    max-width: none;
-    width: 100%;
-  }
+	.story-content {
+		max-width: none;
+		width: 100%;
+	}
 
-  .section-content {
-    max-width: 800px;
-    margin: 0 auto;
-    padding: 0 2rem;
-  }
+	.section-content {
+		max-width: 800px;
+		margin: 0 auto;
+		padding: 0 2rem;
+	}
 
-  .unknown-component {
-    background: #f3f4f6;
-    border: 2px dashed #9ca3af;
-    padding: 2rem;
-    margin: 2rem auto;
-    max-width: 800px;
-    border-radius: 8px;
-  }
+	.unknown-component {
+		background: #f3f4f6;
+		border: 2px dashed #9ca3af;
+		padding: 2rem;
+		margin: 2rem auto;
+		max-width: 800px;
+		border-radius: 8px;
+	}
 
-  .unknown-component pre {
-    background: #ffffff;
-    padding: 1rem;
-    border-radius: 4px;
-    overflow-x: auto;
-    font-size: 0.875rem;
-  }
+	.unknown-component pre {
+		background: #ffffff;
+		padding: 1rem;
+		border-radius: 4px;
+		overflow-x: auto;
+		font-size: 0.875rem;
+	}
 </style>

--- a/src/lib/components/story/VideoScrollytelling.svelte
+++ b/src/lib/components/story/VideoScrollytelling.svelte
@@ -1,919 +1,957 @@
 <!-- VideoScrollytelling.svelte - VERSÃO OTIMIZADA COM PERFORMANCE -->
 <script>
-  import { onMount, onDestroy, tick } from 'svelte';
-  import { browser } from '$app/environment';
-  
-  // Props principais
-  export let videoSrc = '';
-  export let videoSrcMobile = '';
-  export let steps = [];
-  export let height = '300vh';
-  export let fullWidth = true;
-  export let showProgress = true;
-  export let showTime = true;
-  export let fallbackFrames = [];
-  export let posterImage = '';
-  
-  // 🆕 Props para geração automática de frames
-  export let imagePrefix = '';
-  export let imagePrefixMobile = '';
-  export let totalFrames = 0;
-  
-  // 🚀 Props de performance
-  export let preloadFrames = 5; // Quantos frames carregar antecipadamente
-  export let bufferSize = 10; // Tamanho do buffer de imagens
-  export let smoothTransition = true; // Transições suaves entre frames
-  export let lazyLoading = true; // Lazy loading para frames distantes
-  
-  // Estados principais
-  let containerElement;
-  let videoElement;
-  let currentStep = 0;
-  let scrollProgress = 0;
-  let isReady = false;
-  let useVideoFallback = false;
-  let userInteracted = false;
-  
-  // Estados de performance
-  let currentFrameIndex = 0;
-  let lastFrameIndex = -1;
-  let loadedFrames = new Map(); // Cache de imagens carregadas
-  let preloadQueue = new Set(); // Fila de preload
-  let isLoading = false;
-  
-  // Detecção de dispositivo
-  let isIOS = false;
-  let isMobile = false;
-  
-  // Scroll handling otimizado
-  let scrollHandler;
-  let ticking = false;
-  let lastScrollTime = 0;
-  
-  // 🎯 Intersection Observer para lazy loading
-  let intersectionObserver;
+	import { onMount, onDestroy, tick } from 'svelte';
+	import { browser } from '$app/environment';
 
-  $: if (browser) {
-    isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
-    isMobile = window.innerWidth <= 768 || isIOS;
-    
-    console.log('🔍 Device & Performance:', {
-      userAgent: navigator.userAgent,
-      isIOS: isIOS,
-      isMobile: isMobile,
-      preloadFrames: preloadFrames,
-      bufferSize: bufferSize,
-      lazyLoading: lazyLoading
-    });
-  }
-  
-  // 🆕 GERAÇÃO AUTOMÁTICA DE FRAMES OTIMIZADA
-  $: generatedFrames = (() => {
-    // Se já tem fallbackFrames definidos, usar eles
-    if (fallbackFrames && fallbackFrames.length > 0) {
-      return fallbackFrames;
-    }
-    
-    // Se tem imagePrefix e totalFrames, gerar automaticamente
-    if (totalFrames > 0) {
-      const prefix = (isMobile && imagePrefixMobile) ? imagePrefixMobile : imagePrefix;
-      
-      if (prefix) {
-        const frames = [];
-        const duration = steps.length > 0 ? Math.max(...steps.map(s => s.time || 0)) : totalFrames;
-        
-        for (let i = 0; i < totalFrames; i++) {
-          const paddedIndex = String(i + 1).padStart(3, '0');
-          const time = duration > 0 ? (i / (totalFrames - 1)) * duration : i;
-          
-          frames.push({
-            index: i,
-            time: time,
-            src: `${prefix}${paddedIndex}.jpg`,
-            alt: `Frame ${i + 1}`,
-            loaded: false,
-            loading: false,
-            element: null
-          });
-        }
-        
-        console.log(`✅ Gerados ${frames.length} frames para otimização:`, frames.slice(0, 3));
-        return frames;
-      }
-    }
-    
-    return [];
-  })();
-  
-  // Escolher estratégia
-  $: actualVideoSrc = (isMobile && videoSrcMobile) ? videoSrcMobile : videoSrc;
-  $: shouldUseFallback = isIOS || useVideoFallback || !actualVideoSrc || generatedFrames.length > 0;
-  
-  // 🚀 CÁLCULO OTIMIZADO DO FRAME ATUAL
-  $: {
-    if (generatedFrames.length > 0) {
-      const newFrameIndex = Math.floor(scrollProgress * (generatedFrames.length - 1));
-      const clampedIndex = Math.max(0, Math.min(newFrameIndex, generatedFrames.length - 1));
-      
-      if (clampedIndex !== currentFrameIndex) {
-        lastFrameIndex = currentFrameIndex;
-        currentFrameIndex = clampedIndex;
-        
-        // Trigger preload inteligente
-        if (browser) {
-          preloadNearbyFrames(currentFrameIndex);
-        }
-      }
-    }
-  }
-  
-  // Step atual
-  $: if (steps.length > 0) {
-    const stepIndex = Math.floor(scrollProgress * steps.length);
-    currentStep = Math.min(stepIndex, steps.length - 1);
-  }
-  
-  // Frame atual para exibição - OTIMIZADO
-  $: currentFrame = shouldUseFallback && generatedFrames.length > 0 
-    ? generatedFrames[currentFrameIndex]
-    : null;
-    
-  // Imagem para mostrar - COM FALLBACK INTELIGENTE
-  $: displayImage = (() => {
-    if (currentFrame?.loaded && currentFrame?.element) {
-      return currentFrame.src;
-    }
-    
-    // Fallback para frame anterior carregado se atual não estiver pronto
-    if (smoothTransition && lastFrameIndex >= 0 && generatedFrames[lastFrameIndex]?.loaded) {
-      return generatedFrames[lastFrameIndex].src;
-    }
-    
-    // Fallback para poster ou primeiro frame
-    return posterImage || (generatedFrames.length > 0 ? generatedFrames[0]?.src : null);
-  })();
-  
-  // 🚀 PRELOAD INTELIGENTE DE FRAMES
-  async function preloadNearbyFrames(centerIndex) {
-    if (!generatedFrames.length || isLoading) return;
-    
-    isLoading = true;
-    
-    // Calcular range de preload
-    const startIndex = Math.max(0, centerIndex - Math.floor(preloadFrames / 2));
-    const endIndex = Math.min(generatedFrames.length - 1, centerIndex + Math.ceil(preloadFrames / 2));
-    
-    // Priorizar frame atual e adjacentes
-    const loadPromises = [];
-    
-    for (let i = startIndex; i <= endIndex; i++) {
-      const frame = generatedFrames[i];
-      
-      if (!frame.loaded && !frame.loading && !preloadQueue.has(i)) {
-        preloadQueue.add(i);
-        loadPromises.push(preloadFrame(frame, i));
-      }
-    }
-    
-    // Limpar frames distantes do buffer para economizar memória
-    if (loadedFrames.size > bufferSize) {
-      cleanupDistantFrames(centerIndex);
-    }
-    
-    await Promise.allSettled(loadPromises);
-    isLoading = false;
-  }
-  
-  // 🖼️ PRELOAD DE FRAME INDIVIDUAL
-  async function preloadFrame(frame, index) {
-    if (frame.loaded || frame.loading) return;
-    
-    frame.loading = true;
-    
-    return new Promise((resolve, reject) => {
-      const img = new Image();
-      
-      img.onload = () => {
-        frame.loaded = true;
-        frame.loading = false;
-        frame.element = img;
-        loadedFrames.set(index, img);
-        preloadQueue.delete(index);
-        
-        console.log(`✅ Frame ${index + 1} carregado:`, frame.src);
-        resolve(img);
-      };
-      
-      img.onerror = (error) => {
-        frame.loading = false;
-        preloadQueue.delete(index);
-        
-        console.warn(`❌ Erro ao carregar frame ${index + 1}:`, frame.src, error);
-        reject(error);
-      };
-      
-      // Definir src por último para evitar race conditions
-      img.src = frame.src;
-    });
-  }
-  
-  // 🧹 LIMPEZA DE FRAMES DISTANTES
-  function cleanupDistantFrames(centerIndex) {
-    const keepRange = bufferSize;
-    
-    for (const [index, img] of loadedFrames.entries()) {
-      const distance = Math.abs(index - centerIndex);
-      
-      if (distance > keepRange) {
-        // Remover da memória
-        if (img && img.src) {
-          img.src = '';
-        }
-        
-        generatedFrames[index].loaded = false;
-        generatedFrames[index].element = null;
-        loadedFrames.delete(index);
-        
-        console.log(`🧹 Frame ${index + 1} removido do buffer`);
-      }
-    }
-  }
-  
-  // Posições dos steps (inalterado)
-  $: stepPositions = steps.map((_, index) => {
-    const stepProgress = scrollProgress * steps.length;
-    const stepStart = index;
-    const stepEnd = index + 1;
-    
-    let localProgress = 0;
-    if (stepProgress >= stepStart && stepProgress <= stepEnd) {
-      localProgress = stepProgress - stepStart;
-    } else if (stepProgress > stepEnd) {
-      localProgress = 1;
-    }
-    
-    let yPosition = 150 - (localProgress * 200);
-    let opacity = 0;
-    
-    if (localProgress >= 0 && localProgress <= 1) {
-      if (localProgress <= 0.1) {
-        opacity = localProgress * 10;
-      } else if (localProgress >= 0.9) {
-        opacity = (1 - localProgress) * 10;
-      } else {
-        opacity = 1;
-      }
-    }
-    
-    if (stepProgress > stepEnd) {
-      yPosition = -50;
-      opacity = 0;
-    }
-    
-    if (stepProgress < stepStart) {
-      yPosition = 150;
-      opacity = 0;
-    }
-    
-    return {
-      yPosition: yPosition,
-      opacity: Math.max(0, Math.min(1, opacity)),
-      isActive: localProgress > 0.1 && localProgress < 0.9
-    };
-  });
+	// Props principais
+	export let videoSrc = '';
+	export let videoSrcMobile = '';
+	export let steps = [];
+	export let height = '300vh';
+	export let fullWidth = true;
+	export let showProgress = true;
+	export let showTime = true;
+	export let fallbackFrames = [];
+	export let posterImage = '';
+	export let forceFrames = false; // força o uso de frames
+	export let frameDuration = 1000 / 30; // duração entre frames (ms)
 
-  onMount(() => {
-    setupScrollListener();
-    setupIntersectionObserver();
-    
-    // Preload inicial
-    if (generatedFrames.length > 0) {
-      preloadNearbyFrames(0);
-    }
-    
-    setTimeout(() => {
-      isReady = true;
-    }, 100); // Reduzido para melhor responsividade
-  });
-  
-  onDestroy(() => {
-    if (scrollHandler) {
-      window.removeEventListener('scroll', scrollHandler);
-    }
-    
-    if (intersectionObserver) {
-      intersectionObserver.disconnect();
-    }
-    
-    // Limpar todas as imagens do cache
-    for (const [index, img] of loadedFrames.entries()) {
-      if (img && img.src) {
-        img.src = '';
-      }
-    }
-    loadedFrames.clear();
-    preloadQueue.clear();
-  });
-  
-  // 🚀 SCROLL LISTENER OTIMIZADO
-  function setupScrollListener() {
-    scrollHandler = () => {
-      const now = performance.now();
-      
-      // Throttle baseado no tempo para melhor performance
-      if (now - lastScrollTime < 16) return; // ~60fps
-      
-      lastScrollTime = now;
-      
-      if (!ticking) {
-        requestAnimationFrame(handleScroll);
-        ticking = true;
-      }
-    };
-    
-    window.addEventListener('scroll', scrollHandler, { passive: true });
-  }
-  
-  // 🔍 INTERSECTION OBSERVER PARA LAZY LOADING
-  function setupIntersectionObserver() {
-    if (!lazyLoading || !browser) return;
-    
-    intersectionObserver = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            // Componente visível - iniciar preload agressivo
-            if (generatedFrames.length > 0 && !isLoading) {
-              preloadNearbyFrames(currentFrameIndex);
-            }
-          }
-        });
-      },
-      {
-        rootMargin: '100px 0px', // Começar preload 100px antes
-        threshold: 0.1
-      }
-    );
-    
-    if (containerElement) {
-      intersectionObserver.observe(containerElement);
-    }
-  }
-  
-  // 📐 CÁLCULO DE SCROLL OTIMIZADO
-  function handleScroll() {
-    if (!containerElement || !isReady) {
-      ticking = false;
-      return;
-    }
-    
-    const rect = containerElement.getBoundingClientRect();
-    const windowHeight = window.innerHeight;
-    const sectionHeight = containerElement.offsetHeight;
-    
-    const startY = 0;
-    const endY = -(sectionHeight - windowHeight);
-    const currentY = rect.top;
-    
-    let newProgress = 0;
-    if (currentY <= startY && currentY >= endY) {
-      newProgress = Math.abs(currentY - startY) / Math.abs(endY - startY);
-    } else if (currentY > startY) {
-      newProgress = 0;
-    } else {
-      newProgress = 1;
-    }
-    
-    scrollProgress = Math.max(0, Math.min(1, newProgress));
-    
-    // Atualizar vídeo se não estiver em fallback
-    if (!shouldUseFallback && videoElement && videoElement.duration) {
-      const targetTime = scrollProgress * videoElement.duration;
-      if (Math.abs(videoElement.currentTime - targetTime) > 0.1) { // Menor threshold para suavidade
-        if (!videoElement.paused) {
-          videoElement.pause();
-        }
-        try {
-          videoElement.currentTime = targetTime;
-        } catch (error) {
-          // Ignorar erros de currentTime
-        }
-      }
-    }
-    
-    ticking = false;
-  }
-  
-  function handleUserInteraction() {
-    if (!userInteracted) {
-      userInteracted = true;
-      
-      if (!shouldUseFallback && videoElement) {
-        videoElement.pause();
-        videoElement.muted = true;
-        videoElement.currentTime = scrollProgress * (videoElement.duration || 0);
-      }
-    }
-  }
-  
-  function formatTime(seconds) {
-    const mins = Math.floor(seconds / 60);
-    const secs = Math.floor(seconds % 60);
-    return `${mins}:${secs.toString().padStart(2, '0')}`;
-  }
+	// 🆕 Props para geração automática de frames
+	export let imagePrefix = '';
+	export let imagePrefixMobile = '';
+	export let totalFrames = 0;
+
+	// 🚀 Props de performance
+	export let preloadFrames = 5; // Quantos frames carregar antecipadamente
+	export let bufferSize = 10; // Tamanho do buffer de imagens
+	export let smoothTransition = true; // Transições suaves entre frames
+	export let lazyLoading = true; // Lazy loading para frames distantes
+
+	// Estados principais
+	let containerElement;
+	let videoElement;
+	let currentStep = 0;
+	let scrollProgress = 0;
+	let isReady = false;
+	let userInteracted = false;
+
+	// Estados de performance
+	let currentFrameIndex = 0;
+	let desiredFrameIndex = 0;
+	let lastFrameIndex = -1;
+	let loadedFrames = new Map(); // Cache de imagens carregadas
+	let preloadQueue = new Set(); // Fila de preload
+	let isLoading = false;
+	let animationFrameId = null;
+	let lastAnimationTime = 0;
+
+	// Detecção de dispositivo
+	let isIOS = false;
+	let isMobile = false;
+
+	// Scroll handling otimizado
+	let scrollHandler;
+	let ticking = false;
+	let lastScrollTime = 0;
+
+	// 🎯 Intersection Observer para lazy loading
+	let intersectionObserver;
+
+	$: if (browser) {
+		isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+		isMobile = window.innerWidth <= 768 || isIOS;
+
+		console.log('🔍 Device & Performance:', {
+			userAgent: navigator.userAgent,
+			isIOS: isIOS,
+			isMobile: isMobile,
+			preloadFrames: preloadFrames,
+			bufferSize: bufferSize,
+			lazyLoading: lazyLoading
+		});
+	}
+
+	// 🆕 GERAÇÃO AUTOMÁTICA DE FRAMES OTIMIZADA
+	$: generatedFrames = (() => {
+		// Se já tem fallbackFrames definidos, usar eles
+		if (fallbackFrames && fallbackFrames.length > 0) {
+			return fallbackFrames;
+		}
+
+		// Se tem imagePrefix e totalFrames, gerar automaticamente
+		if (totalFrames > 0) {
+			const prefix = isMobile && imagePrefixMobile ? imagePrefixMobile : imagePrefix;
+
+			if (prefix) {
+				const frames = [];
+				const duration =
+					steps.length > 0 ? Math.max(...steps.map((s) => s.time || 0)) : totalFrames;
+
+				for (let i = 0; i < totalFrames; i++) {
+					const paddedIndex = String(i + 1).padStart(3, '0');
+					const time = duration > 0 ? (i / (totalFrames - 1)) * duration : i;
+
+					frames.push({
+						index: i,
+						time: time,
+						src: `${prefix}${paddedIndex}.jpg`,
+						alt: `Frame ${i + 1}`,
+						loaded: false,
+						loading: false,
+						element: null
+					});
+				}
+
+				console.log(`✅ Gerados ${frames.length} frames para otimização:`, frames.slice(0, 3));
+				return frames;
+			}
+		}
+
+		return [];
+	})();
+
+	// Escolher estratégia
+	$: actualVideoSrc = isMobile && videoSrcMobile ? videoSrcMobile : videoSrc;
+	$: shouldUseFallback = forceFrames || isMobile || !actualVideoSrc;
+
+	// 🚀 CÁLCULO OTIMIZADO DO FRAME ATUAL
+	$: if (shouldUseFallback && generatedFrames.length > 0) {
+		desiredFrameIndex = Math.max(
+			0,
+			Math.min(
+				Math.floor(scrollProgress * (generatedFrames.length - 1)),
+				generatedFrames.length - 1
+			)
+		);
+		if (animationFrameId === null) {
+			animationFrameId = requestAnimationFrame(animateFrames);
+		}
+	}
+
+	// Step atual
+	$: if (steps.length > 0) {
+		const stepIndex = Math.floor(scrollProgress * steps.length);
+		currentStep = Math.min(stepIndex, steps.length - 1);
+	}
+
+	// Frame atual para exibição - OTIMIZADO
+	$: currentFrame =
+		shouldUseFallback && generatedFrames.length > 0 ? generatedFrames[currentFrameIndex] : null;
+
+	// Imagem para mostrar - COM FALLBACK INTELIGENTE
+	$: displayImage = (() => {
+		if (currentFrame?.loaded && currentFrame?.element) {
+			return currentFrame.src;
+		}
+
+		// Fallback para frame anterior carregado se atual não estiver pronto
+		if (smoothTransition && lastFrameIndex >= 0 && generatedFrames[lastFrameIndex]?.loaded) {
+			return generatedFrames[lastFrameIndex].src;
+		}
+
+		// Fallback para poster ou primeiro frame
+		return posterImage || (generatedFrames.length > 0 ? generatedFrames[0]?.src : null);
+	})();
+
+	// 🚀 PRELOAD INTELIGENTE DE FRAMES
+	async function preloadNearbyFrames(centerIndex) {
+		if (!generatedFrames.length || isLoading) return;
+
+		isLoading = true;
+
+		// Calcular range de preload
+		const startIndex = Math.max(0, centerIndex - Math.floor(preloadFrames / 2));
+		const endIndex = Math.min(
+			generatedFrames.length - 1,
+			centerIndex + Math.ceil(preloadFrames / 2)
+		);
+
+		// Priorizar frame atual e adjacentes
+		const loadPromises = [];
+
+		for (let i = startIndex; i <= endIndex; i++) {
+			const frame = generatedFrames[i];
+
+			if (!frame.loaded && !frame.loading && !preloadQueue.has(i)) {
+				preloadQueue.add(i);
+				loadPromises.push(preloadFrame(frame, i));
+			}
+		}
+
+		// Limpar frames distantes do buffer para economizar memória
+		if (loadedFrames.size > bufferSize) {
+			cleanupDistantFrames(centerIndex);
+		}
+
+		await Promise.allSettled(loadPromises);
+		isLoading = false;
+	}
+
+	// 🖼️ PRELOAD DE FRAME INDIVIDUAL
+	async function preloadFrame(frame, index) {
+		if (frame.loaded || frame.loading) return;
+
+		frame.loading = true;
+
+		return new Promise((resolve, reject) => {
+			const img = new Image();
+
+			img.onload = () => {
+				frame.loaded = true;
+				frame.loading = false;
+				frame.element = img;
+				loadedFrames.set(index, img);
+				preloadQueue.delete(index);
+
+				console.log(`✅ Frame ${index + 1} carregado:`, frame.src);
+				resolve(img);
+			};
+
+			img.onerror = (error) => {
+				frame.loading = false;
+				preloadQueue.delete(index);
+
+				console.warn(`❌ Erro ao carregar frame ${index + 1}:`, frame.src, error);
+				reject(error);
+			};
+
+			// Definir src por último para evitar race conditions
+			img.src = frame.src;
+		});
+	}
+
+	// 🧹 LIMPEZA DE FRAMES DISTANTES
+	function cleanupDistantFrames(centerIndex) {
+		const keepRange = bufferSize;
+
+		for (const [index, img] of loadedFrames.entries()) {
+			const distance = Math.abs(index - centerIndex);
+
+			if (distance > keepRange) {
+				// Remover da memória
+				if (img && img.src) {
+					img.src = '';
+				}
+
+				generatedFrames[index].loaded = false;
+				generatedFrames[index].element = null;
+				loadedFrames.delete(index);
+
+				console.log(`🧹 Frame ${index + 1} removido do buffer`);
+			}
+		}
+	}
+
+	// 🎞️ Animação frame a frame com ritmo constante
+	function animateFrames(timestamp) {
+		if (timestamp - lastAnimationTime >= frameDuration) {
+			if (currentFrameIndex < desiredFrameIndex) {
+				lastFrameIndex = currentFrameIndex;
+				currentFrameIndex += 1;
+			} else if (currentFrameIndex > desiredFrameIndex) {
+				lastFrameIndex = currentFrameIndex;
+				currentFrameIndex -= 1;
+			}
+
+			lastAnimationTime = timestamp;
+
+			if (browser) {
+				preloadNearbyFrames(currentFrameIndex);
+			}
+		}
+
+		if (currentFrameIndex !== desiredFrameIndex) {
+			animationFrameId = requestAnimationFrame(animateFrames);
+		} else {
+			animationFrameId = null;
+		}
+	}
+
+	// Posições dos steps (inalterado)
+	$: stepPositions = steps.map((_, index) => {
+		const stepProgress = scrollProgress * steps.length;
+		const stepStart = index;
+		const stepEnd = index + 1;
+
+		let localProgress = 0;
+		if (stepProgress >= stepStart && stepProgress <= stepEnd) {
+			localProgress = stepProgress - stepStart;
+		} else if (stepProgress > stepEnd) {
+			localProgress = 1;
+		}
+
+		let yPosition = 150 - localProgress * 200;
+		let opacity = 0;
+
+		if (localProgress >= 0 && localProgress <= 1) {
+			if (localProgress <= 0.1) {
+				opacity = localProgress * 10;
+			} else if (localProgress >= 0.9) {
+				opacity = (1 - localProgress) * 10;
+			} else {
+				opacity = 1;
+			}
+		}
+
+		if (stepProgress > stepEnd) {
+			yPosition = -50;
+			opacity = 0;
+		}
+
+		if (stepProgress < stepStart) {
+			yPosition = 150;
+			opacity = 0;
+		}
+
+		return {
+			yPosition: yPosition,
+			opacity: Math.max(0, Math.min(1, opacity)),
+			isActive: localProgress > 0.1 && localProgress < 0.9
+		};
+	});
+
+	onMount(() => {
+		setupScrollListener();
+		setupIntersectionObserver();
+
+		// Preload inicial
+		if (generatedFrames.length > 0) {
+			preloadNearbyFrames(0);
+		}
+
+		setTimeout(() => {
+			isReady = true;
+		}, 100); // Reduzido para melhor responsividade
+	});
+
+	onDestroy(() => {
+		if (scrollHandler) {
+			window.removeEventListener('scroll', scrollHandler);
+		}
+
+		if (intersectionObserver) {
+			intersectionObserver.disconnect();
+		}
+
+		if (animationFrameId) {
+			cancelAnimationFrame(animationFrameId);
+		}
+
+		// Limpar todas as imagens do cache
+		for (const [index, img] of loadedFrames.entries()) {
+			if (img && img.src) {
+				img.src = '';
+			}
+		}
+		loadedFrames.clear();
+		preloadQueue.clear();
+	});
+
+	// 🚀 SCROLL LISTENER OTIMIZADO
+	function setupScrollListener() {
+		scrollHandler = () => {
+			const now = performance.now();
+
+			// Throttle baseado no tempo para melhor performance
+			if (now - lastScrollTime < 16) return; // ~60fps
+
+			lastScrollTime = now;
+
+			if (!ticking) {
+				requestAnimationFrame(handleScroll);
+				ticking = true;
+			}
+		};
+
+		window.addEventListener('scroll', scrollHandler, { passive: true });
+	}
+
+	// 🔍 INTERSECTION OBSERVER PARA LAZY LOADING
+	function setupIntersectionObserver() {
+		if (!lazyLoading || !browser) return;
+
+		intersectionObserver = new IntersectionObserver(
+			(entries) => {
+				entries.forEach((entry) => {
+					if (entry.isIntersecting) {
+						// Componente visível - iniciar preload agressivo
+						if (generatedFrames.length > 0 && !isLoading) {
+							preloadNearbyFrames(currentFrameIndex);
+						}
+					}
+				});
+			},
+			{
+				rootMargin: '100px 0px', // Começar preload 100px antes
+				threshold: 0.1
+			}
+		);
+
+		if (containerElement) {
+			intersectionObserver.observe(containerElement);
+		}
+	}
+
+	// 📐 CÁLCULO DE SCROLL OTIMIZADO
+	function handleScroll() {
+		if (!containerElement || !isReady) {
+			ticking = false;
+			return;
+		}
+
+		const rect = containerElement.getBoundingClientRect();
+		const windowHeight = window.innerHeight;
+		const sectionHeight = containerElement.offsetHeight;
+
+		const startY = 0;
+		const endY = -(sectionHeight - windowHeight);
+		const currentY = rect.top;
+
+		let newProgress = 0;
+		if (currentY <= startY && currentY >= endY) {
+			newProgress = Math.abs(currentY - startY) / Math.abs(endY - startY);
+		} else if (currentY > startY) {
+			newProgress = 0;
+		} else {
+			newProgress = 1;
+		}
+
+		scrollProgress = Math.max(0, Math.min(1, newProgress));
+
+		// Atualizar vídeo se não estiver em fallback
+		if (!shouldUseFallback && videoElement && videoElement.duration) {
+			const targetTime = scrollProgress * videoElement.duration;
+			if (Math.abs(videoElement.currentTime - targetTime) > 0.1) {
+				// Menor threshold para suavidade
+				if (!videoElement.paused) {
+					videoElement.pause();
+				}
+				try {
+					videoElement.currentTime = targetTime;
+				} catch (error) {
+					// Ignorar erros de currentTime
+				}
+			}
+		}
+
+		ticking = false;
+	}
+
+	function handleUserInteraction() {
+		if (!userInteracted) {
+			userInteracted = true;
+
+			if (!shouldUseFallback && videoElement) {
+				videoElement.pause();
+				videoElement.muted = true;
+				videoElement.currentTime = scrollProgress * (videoElement.duration || 0);
+			}
+		}
+	}
+
+	function formatTime(seconds) {
+		const mins = Math.floor(seconds / 60);
+		const secs = Math.floor(seconds % 60);
+		return `${mins}:${secs.toString().padStart(2, '0')}`;
+	}
 </script>
 
-<section 
-  class="video-scrollytelling"
-  class:full-width={fullWidth}
-  class:smooth-transition={smoothTransition}
-  style="height: {height};"
-  bind:this={containerElement}
-  on:touchstart={handleUserInteraction}
-  on:click={handleUserInteraction}
+<section
+	class="video-scrollytelling"
+	class:full-width={fullWidth}
+	class:smooth-transition={smoothTransition}
+	style="height: {height};"
+	bind:this={containerElement}
+	on:touchstart={handleUserInteraction}
+	on:click={handleUserInteraction}
 >
-  <!-- Media Container - STICKY -->
-  <div class="media-container">
-    
-    <!-- Performance Debug -->
-    <div class="debug-overlay">
-      <div>iOS: {isIOS ? 'SIM' : 'NÃO'}</div>
-      <div>Mobile: {isMobile ? 'SIM' : 'NÃO'}</div>
-      <div>Fallback: {shouldUseFallback ? 'SIM' : 'NÃO'}</div>
-      <div>Frames: {generatedFrames.length}</div>
-      <div>Progress: {Math.round(scrollProgress * 100)}%</div>
-      <div>Frame: {currentFrameIndex + 1}/{generatedFrames.length}</div>
-      <div>Loaded: {loadedFrames.size}</div>
-      <div>Preload Queue: {preloadQueue.size}</div>
-      <div class:loading={isLoading}>Loading: {isLoading ? 'SIM' : 'NÃO'}</div>
-      {#if displayImage}
-        <div style="font-size: 10px; word-break: break-all;">URL: {displayImage.substring(0, 50)}...</div>
-      {/if}
-    </div>
-    
-    <!-- Vídeo (desktop/android apenas quando NÃO é iOS e NÃO tem frames gerados) -->
-    {#if !shouldUseFallback && actualVideoSrc}
-      <video
-        bind:this={videoElement}
-        src={actualVideoSrc}
-        poster={displayImage}
-        muted
-        playsinline
-        webkit-playsinline="true"
-        preload="metadata"
-        class="scroll-video"
-        autoplay={false}
-        loop={false}
-      >
-        <track kind="captions" />
-      </video>
-    {/if}
-    
-    <!-- 🎯 IMAGEM OTIMIZADA PARA iOS E FALLBACK -->
-    {#if shouldUseFallback && displayImage}
-      <img
-        src={displayImage}
-        alt="Video frame {currentFrameIndex + 1}"
-        class="fallback-image"
-        class:smooth={smoothTransition}
-        loading="eager"
-        decoding="async"
-        on:load={() => console.log('✅ Frame exibido:', currentFrameIndex + 1, displayImage)}
-        on:error={(e) => console.log('❌ Erro no frame:', currentFrameIndex + 1, displayImage, e)}
-      />
-    {/if}
-    
-    <!-- Loading indicator -->
-    {#if isLoading && shouldUseFallback}
-      <div class="loading-indicator">
-        <div class="loading-spinner"></div>
-        <span>Carregando frames...</span>
-      </div>
-    {/if}
-    
-    <!-- Placeholder quando não tem nada -->
-    {#if !displayImage && !actualVideoSrc}
-      <div class="placeholder">
-        <div class="placeholder-content">
-          <p>🎬 VideoScrollytelling Otimizado</p>
-          <p>iOS: {isIOS ? 'Detectado' : 'Não detectado'}</p>
-          <p>Frames Gerados: {generatedFrames.length}</p>
-          <p>Performance: {preloadFrames} preload, {bufferSize} buffer</p>
-          <p>ImagePrefix: {imagePrefix ? 'Definido' : 'Não definido'}</p>
-          <p>TotalFrames: {totalFrames}</p>
-        </div>
-      </div>
-    {/if}
-    
-    <!-- iOS Play Button (apenas quando tem vídeo mas não tem frames) -->
-    {#if isIOS && !userInteracted && !shouldUseFallback && actualVideoSrc}
-      <div class="ios-prompt">
-        <button 
-          class="play-button"
-          on:click={handleUserInteraction}
-        >
-          <svg width="60" height="60" viewBox="0 0 60 60">
-            <circle cx="30" cy="30" r="30" fill="rgba(0,0,0,0.7)"/>
-            <polygon points="22,18 22,42 42,30" fill="white"/>
-          </svg>
-          <span>Toque para iniciar</span>
-        </button>
-      </div>
-    {/if}
-  </div>
-  
-  <!-- Steps Container - TAMBÉM STICKY -->
-  <div class="steps-container">
-    {#each steps as step, index}
-      <div 
-        class="step"
-        class:active={stepPositions[index]?.isActive}
-        class:visible={isReady}
-        style="
+	<!-- Media Container - STICKY -->
+	<div class="media-container">
+		<!-- Performance Debug -->
+		<div class="debug-overlay">
+			<div>iOS: {isIOS ? 'SIM' : 'NÃO'}</div>
+			<div>Mobile: {isMobile ? 'SIM' : 'NÃO'}</div>
+			<div>Fallback: {shouldUseFallback ? 'SIM' : 'NÃO'}</div>
+			<div>Force: {forceFrames ? 'SIM' : 'NÃO'}</div>
+			<div>Frames: {generatedFrames.length}</div>
+			<div>Progress: {Math.round(scrollProgress * 100)}%</div>
+			<div>Frame: {currentFrameIndex + 1}/{generatedFrames.length}</div>
+			<div>Loaded: {loadedFrames.size}</div>
+			<div>Preload Queue: {preloadQueue.size}</div>
+			<div class:loading={isLoading}>Loading: {isLoading ? 'SIM' : 'NÃO'}</div>
+			{#if displayImage}
+				<div style="font-size: 10px; word-break: break-all;">
+					URL: {displayImage.substring(0, 50)}...
+				</div>
+			{/if}
+		</div>
+
+		<!-- Vídeo (desktop/android apenas quando NÃO é iOS e NÃO tem frames gerados) -->
+		{#if !shouldUseFallback && actualVideoSrc}
+			<video
+				bind:this={videoElement}
+				src={actualVideoSrc}
+				poster={displayImage}
+				muted
+				playsinline
+				webkit-playsinline="true"
+				preload="metadata"
+				class="scroll-video"
+				autoplay={false}
+				loop={false}
+			>
+				<track kind="captions" />
+			</video>
+		{/if}
+
+		<!-- 🎯 IMAGEM OTIMIZADA PARA iOS E FALLBACK -->
+		{#if shouldUseFallback && displayImage}
+			<img
+				src={displayImage}
+				alt="Video frame {currentFrameIndex + 1}"
+				class="fallback-image"
+				class:smooth={smoothTransition}
+				loading="eager"
+				decoding="async"
+				on:load={() => console.log('✅ Frame exibido:', currentFrameIndex + 1, displayImage)}
+				on:error={(e) => console.log('❌ Erro no frame:', currentFrameIndex + 1, displayImage, e)}
+			/>
+		{/if}
+
+		<!-- Loading indicator -->
+		{#if isLoading && shouldUseFallback}
+			<div class="loading-indicator">
+				<div class="loading-spinner"></div>
+				<span>Carregando frames...</span>
+			</div>
+		{/if}
+
+		<!-- Placeholder quando não tem nada -->
+		{#if !displayImage && !actualVideoSrc}
+			<div class="placeholder">
+				<div class="placeholder-content">
+					<p>🎬 VideoScrollytelling Otimizado</p>
+					<p>iOS: {isIOS ? 'Detectado' : 'Não detectado'}</p>
+					<p>Frames Gerados: {generatedFrames.length}</p>
+					<p>Performance: {preloadFrames} preload, {bufferSize} buffer</p>
+					<p>ImagePrefix: {imagePrefix ? 'Definido' : 'Não definido'}</p>
+					<p>TotalFrames: {totalFrames}</p>
+				</div>
+			</div>
+		{/if}
+
+		<!-- iOS Play Button (apenas quando tem vídeo mas não tem frames) -->
+		{#if isIOS && !userInteracted && !shouldUseFallback && actualVideoSrc}
+			<div class="ios-prompt">
+				<button class="play-button" on:click={handleUserInteraction}>
+					<svg width="60" height="60" viewBox="0 0 60 60">
+						<circle cx="30" cy="30" r="30" fill="rgba(0,0,0,0.7)" />
+						<polygon points="22,18 22,42 42,30" fill="white" />
+					</svg>
+					<span>Toque para iniciar</span>
+				</button>
+			</div>
+		{/if}
+	</div>
+
+	<!-- Steps Container - TAMBÉM STICKY -->
+	<div class="steps-container">
+		{#each steps as step, index}
+			<div
+				class="step"
+				class:active={stepPositions[index]?.isActive}
+				class:visible={isReady}
+				style="
           transform: translateY({stepPositions[index]?.yPosition || 150}vh);
           opacity: {stepPositions[index]?.opacity || 0};
         "
-      >
-        <div class="step-content">
-          <div class="step-number">{index + 1}</div>
-          <h3>{step.title}</h3>
-          <div class="step-text">{@html step.text}</div>
-          {#if showTime && step.time}
-            <div class="step-time">{formatTime(step.time)}</div>
-          {/if}
-        </div>
-      </div>
-    {/each}
-  </div>
-  
-  <!-- Progress Bar Otimizada -->
-  {#if showProgress && isReady}
-    <div class="progress-bar">
-      <div 
-        class="progress-fill" 
-        style="width: {scrollProgress * 100}%"
-      ></div>
-      <div class="progress-frame-indicator" style="left: {(currentFrameIndex / (generatedFrames.length - 1)) * 100}%"></div>
-    </div>
-  {/if}
+			>
+				<div class="step-content">
+					<div class="step-number">{index + 1}</div>
+					<h3>{step.title}</h3>
+					<div class="step-text">{@html step.text}</div>
+					{#if showTime && step.time}
+						<div class="step-time">{formatTime(step.time)}</div>
+					{/if}
+				</div>
+			</div>
+		{/each}
+	</div>
+
+	<!-- Progress Bar Otimizada -->
+	{#if showProgress && isReady}
+		<div class="progress-bar">
+			<div class="progress-fill" style="width: {scrollProgress * 100}%"></div>
+			<div
+				class="progress-frame-indicator"
+				style="left: {(currentFrameIndex / (generatedFrames.length - 1)) * 100}%"
+			></div>
+		</div>
+	{/if}
 </section>
 
 <style>
-  .video-scrollytelling {
-    position: relative;
-    width: 100%;
-    background: #000;
-  }
-  
-  .video-scrollytelling.full-width {
-    width: 100vw;
-    margin-left: calc(-50vw + 50%);
-  }
-  
-  .media-container {
-    position: sticky;
-    top: 0;
-    width: 100%;
-    height: 100vh;
-    overflow: hidden;
-    z-index: 1;
-    background: #000;
-  }
-  
-  .scroll-video,
-  .fallback-image {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    display: block;
-  }
-  
-  /* 🚀 TRANSIÇÕES SUAVES */
-  .fallback-image.smooth {
-    transition: opacity 0.1s ease-out;
-  }
-  
-  .smooth-transition .fallback-image {
-    transition: opacity 0.05s ease-out;
-  }
-  
-  .placeholder {
-    width: 100%;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: #111;
-    color: #666;
-  }
-  
-  .placeholder-content {
-    text-align: center;
-  }
-  
-  .placeholder-content p {
-    font-size: 1.2rem;
-    margin: 0.5rem 0;
-  }
-  
-  /* 🔄 LOADING INDICATOR */
-  .loading-indicator {
-    position: absolute;
-    top: 20px;
-    right: 20px;
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    background: rgba(0, 0, 0, 0.8);
-    color: white;
-    padding: 10px 15px;
-    border-radius: 20px;
-    font-size: 12px;
-    z-index: 50;
-  }
-  
-  .loading-spinner {
-    width: 16px;
-    height: 16px;
-    border: 2px solid rgba(255, 255, 255, 0.3);
-    border-top: 2px solid white;
-    border-radius: 50%;
-    animation: spin 1s linear infinite;
-  }
-  
-  @keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
-  }
-  
-  .ios-prompt {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: rgba(0, 0, 0, 0.5);
-    z-index: 5;
-  }
-  
-  .play-button {
-    background: none;
-    border: none;
-    color: white;
-    cursor: pointer;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 1rem;
-    font-size: 1rem;
-  }
-  
-  .steps-container {
-    position: sticky;
-    top: 0;
-    width: 100%;
-    height: 100vh;
-    pointer-events: none;
-    z-index: 10;
-  }
-  
-  .step {
-    position: absolute;
-    top: 0;
-    left: 2rem;
-    right: 2rem;
-    height: 100vh;
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
-    pointer-events: none;
-    transition: opacity 0.2s ease-out, transform 0.2s ease-out;
-  }
-  
-  .step-content {
-    background: rgba(0, 0, 0, 0.85);
-    backdrop-filter: blur(10px);
-    color: white;
-    padding: 2rem;
-    border-radius: 12px;
-    max-width: 500px;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
-    border: 1px solid rgba(255, 255, 255, 0.1);
-  }
-  
-  .step-number {
-    display: inline-block;
-    background: linear-gradient(135deg, #667eea, #764ba2);
-    color: white;
-    width: 30px;
-    height: 30px;
-    border-radius: 50%;
-    text-align: center;
-    line-height: 30px;
-    font-weight: bold;
-    margin-bottom: 1rem;
-    font-size: 14px;
-  }
-  
-  .step-content h3 {
-    margin: 0 0 1rem 0;
-    font-size: 1.5rem;
-    font-weight: bold;
-    line-height: 1.3;
-  }
-  
-  .step-text {
-    line-height: 1.6;
-    margin-bottom: 1rem;
-  }
-  
-  .step-text :global(strong) {
-    color: #ffd700;
-  }
-  
-  .step-text :global(em) {
-    color: #87ceeb;
-  }
-  
-  .step-time {
-    display: inline-block;
-    padding: 0.5rem 1rem;
-    background: rgba(255, 255, 255, 0.2);
-    border-radius: 20px;
-    font-size: 0.9rem;
-    font-family: monospace;
-  }
-  
-  /* 🚀 PROGRESS BAR OTIMIZADA */
-  .progress-bar {
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    height: 4px;
-    background: rgba(255, 255, 255, 0.3);
-    z-index: 15;
-  }
-  
-  .progress-fill {
-    height: 100%;
-    background: linear-gradient(90deg, #667eea, #764ba2);
-    transition: width 0.05s ease;
-  }
-  
-  .progress-frame-indicator {
-    position: absolute;
-    top: -2px;
-    width: 2px;
-    height: 8px;
-    background: #ffd700;
-    transition: left 0.05s ease;
-  }
-  
-  /* 🐛 DEBUG OVERLAY OTIMIZADO */
-  .debug-overlay {
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    background: rgba(0, 0, 0, 0.9);
-    color: white;
-    padding: 10px;
-    font-size: 11px;
-    z-index: 100;
-    border-radius: 4px;
-    font-family: monospace;
-    min-width: 200px;
-  }
-  
-  .debug-overlay div {
-    margin: 2px 0;
-    display: flex;
-    justify-content: space-between;
-  }
-  
-  .debug-overlay .loading {
-    color: #ffd700;
-    font-weight: bold;
-  }
-  
-  /* Mobile otimizações */
-  @media (max-width: 768px) {
-    .step {
-      left: 1rem;
-      right: 1rem;
-    }
-    
-    .step-content {
-      padding: 1.5rem;
-    }
-    
-    .step-content h3 {
-      font-size: 1.25rem;
-    }
-    
-    .debug-overlay {
-      font-size: 10px;
-      padding: 8px;
-      min-width: 180px;
-    }
-    
-    .loading-indicator {
-      top: 10px;
-      right: 10px;
-      padding: 8px 12px;
-      font-size: 11px;
-    }
-    
-    /* Otimizações de performance mobile */
-    .fallback-image {
-      image-rendering: -webkit-optimize-contrast;
-      image-rendering: crisp-edges;
-    }
-  }
-  
-  /* Otimizações de performance geral */
-  .video-scrollytelling {
-    contain: layout style paint;
-    will-change: scroll-position;
-  }
-  
-  .media-container {
-    contain: layout style paint;
-  }
-  
-  .fallback-image {
-    will-change: opacity;
-    backface-visibility: hidden;
-    transform: translateZ(0);
-  }
-  
-  /* Reduced motion */
-  @media (prefers-reduced-motion: reduce) {
-    .step,
-    .progress-fill,
-    .progress-frame-indicator,
-    .fallback-image.smooth,
-    .play-button {
-      transition: none;
-    }
-    
-    .loading-spinner {
-      animation: none;
-    }
-  }
-  
-  /* High performance mode */
-  @media (min-resolution: 2dppx) {
-    .fallback-image {
-      image-rendering: -webkit-optimize-contrast;
-    }
-  }
-  
-  /* Dark mode support */
-  @media (prefers-color-scheme: dark) {
-    .placeholder {
-      background: #0a0a0a;
-      color: #888;
-    }
-    
-    .debug-overlay {
-      background: rgba(10, 10, 10, 0.95);
-      border: 1px solid rgba(255, 255, 255, 0.1);
-    }
-  }
-  
-  /* Print styles */
-  @media print {
-    .video-scrollytelling {
-      height: auto !important;
-      page-break-inside: avoid;
-    }
-    
-    .debug-overlay,
-    .loading-indicator,
-    .progress-bar {
-      display: none !important;
-    }
-    
-    .fallback-image {
-      position: static;
-      max-height: 400px;
-      object-fit: contain;
-    }
-    
-    .steps-container {
-      position: static;
-      height: auto;
-    }
-    
-    .step {
-      position: static;
-      opacity: 1 !important;
-      transform: none !important;
-      margin: 20px 0;
-    }
-  }
+	.video-scrollytelling {
+		position: relative;
+		width: 100%;
+		background: #000;
+	}
+
+	.video-scrollytelling.full-width {
+		width: 100vw;
+		margin-left: calc(-50vw + 50%);
+	}
+
+	.media-container {
+		position: sticky;
+		top: 0;
+		width: 100%;
+		height: 100vh;
+		overflow: hidden;
+		z-index: 1;
+		background: #000;
+	}
+
+	.scroll-video,
+	.fallback-image {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		display: block;
+	}
+
+	/* 🚀 TRANSIÇÕES SUAVES */
+	.fallback-image.smooth {
+		transition: opacity 0.1s ease-out;
+	}
+
+	.smooth-transition .fallback-image {
+		transition: opacity 0.05s ease-out;
+	}
+
+	.placeholder {
+		width: 100%;
+		height: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: #111;
+		color: #666;
+	}
+
+	.placeholder-content {
+		text-align: center;
+	}
+
+	.placeholder-content p {
+		font-size: 1.2rem;
+		margin: 0.5rem 0;
+	}
+
+	/* 🔄 LOADING INDICATOR */
+	.loading-indicator {
+		position: absolute;
+		top: 20px;
+		right: 20px;
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		background: rgba(0, 0, 0, 0.8);
+		color: white;
+		padding: 10px 15px;
+		border-radius: 20px;
+		font-size: 12px;
+		z-index: 50;
+	}
+
+	.loading-spinner {
+		width: 16px;
+		height: 16px;
+		border: 2px solid rgba(255, 255, 255, 0.3);
+		border-top: 2px solid white;
+		border-radius: 50%;
+		animation: spin 1s linear infinite;
+	}
+
+	@keyframes spin {
+		0% {
+			transform: rotate(0deg);
+		}
+		100% {
+			transform: rotate(360deg);
+		}
+	}
+
+	.ios-prompt {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: rgba(0, 0, 0, 0.5);
+		z-index: 5;
+	}
+
+	.play-button {
+		background: none;
+		border: none;
+		color: white;
+		cursor: pointer;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 1rem;
+		font-size: 1rem;
+	}
+
+	.steps-container {
+		position: sticky;
+		top: 0;
+		width: 100%;
+		height: 100vh;
+		pointer-events: none;
+		z-index: 10;
+	}
+
+	.step {
+		position: absolute;
+		top: 0;
+		left: 2rem;
+		right: 2rem;
+		height: 100vh;
+		display: flex;
+		align-items: center;
+		justify-content: flex-start;
+		pointer-events: none;
+		transition:
+			opacity 0.2s ease-out,
+			transform 0.2s ease-out;
+	}
+
+	.step-content {
+		background: rgba(0, 0, 0, 0.85);
+		backdrop-filter: blur(10px);
+		color: white;
+		padding: 2rem;
+		border-radius: 12px;
+		max-width: 500px;
+		box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+		border: 1px solid rgba(255, 255, 255, 0.1);
+	}
+
+	.step-number {
+		display: inline-block;
+		background: linear-gradient(135deg, #667eea, #764ba2);
+		color: white;
+		width: 30px;
+		height: 30px;
+		border-radius: 50%;
+		text-align: center;
+		line-height: 30px;
+		font-weight: bold;
+		margin-bottom: 1rem;
+		font-size: 14px;
+	}
+
+	.step-content h3 {
+		margin: 0 0 1rem 0;
+		font-size: 1.5rem;
+		font-weight: bold;
+		line-height: 1.3;
+	}
+
+	.step-text {
+		line-height: 1.6;
+		margin-bottom: 1rem;
+	}
+
+	.step-text :global(strong) {
+		color: #ffd700;
+	}
+
+	.step-text :global(em) {
+		color: #87ceeb;
+	}
+
+	.step-time {
+		display: inline-block;
+		padding: 0.5rem 1rem;
+		background: rgba(255, 255, 255, 0.2);
+		border-radius: 20px;
+		font-size: 0.9rem;
+		font-family: monospace;
+	}
+
+	/* 🚀 PROGRESS BAR OTIMIZADA */
+	.progress-bar {
+		position: fixed;
+		bottom: 0;
+		left: 0;
+		width: 100%;
+		height: 4px;
+		background: rgba(255, 255, 255, 0.3);
+		z-index: 15;
+	}
+
+	.progress-fill {
+		height: 100%;
+		background: linear-gradient(90deg, #667eea, #764ba2);
+		transition: width 0.05s ease;
+	}
+
+	.progress-frame-indicator {
+		position: absolute;
+		top: -2px;
+		width: 2px;
+		height: 8px;
+		background: #ffd700;
+		transition: left 0.05s ease;
+	}
+
+	/* 🐛 DEBUG OVERLAY OTIMIZADO */
+	.debug-overlay {
+		position: absolute;
+		top: 10px;
+		left: 10px;
+		background: rgba(0, 0, 0, 0.9);
+		color: white;
+		padding: 10px;
+		font-size: 11px;
+		z-index: 100;
+		border-radius: 4px;
+		font-family: monospace;
+		min-width: 200px;
+	}
+
+	.debug-overlay div {
+		margin: 2px 0;
+		display: flex;
+		justify-content: space-between;
+	}
+
+	.debug-overlay .loading {
+		color: #ffd700;
+		font-weight: bold;
+	}
+
+	/* Mobile otimizações */
+	@media (max-width: 768px) {
+		.step {
+			left: 1rem;
+			right: 1rem;
+		}
+
+		.step-content {
+			padding: 1.5rem;
+		}
+
+		.step-content h3 {
+			font-size: 1.25rem;
+		}
+
+		.debug-overlay {
+			font-size: 10px;
+			padding: 8px;
+			min-width: 180px;
+		}
+
+		.loading-indicator {
+			top: 10px;
+			right: 10px;
+			padding: 8px 12px;
+			font-size: 11px;
+		}
+
+		/* Otimizações de performance mobile */
+		.fallback-image {
+			image-rendering: -webkit-optimize-contrast;
+			image-rendering: crisp-edges;
+		}
+	}
+
+	/* Otimizações de performance geral */
+	.video-scrollytelling {
+		contain: layout style paint;
+		will-change: scroll-position;
+	}
+
+	.media-container {
+		contain: layout style paint;
+	}
+
+	.fallback-image {
+		will-change: opacity;
+		backface-visibility: hidden;
+		transform: translateZ(0);
+	}
+
+	/* Reduced motion */
+	@media (prefers-reduced-motion: reduce) {
+		.step,
+		.progress-fill,
+		.progress-frame-indicator,
+		.fallback-image.smooth,
+		.play-button {
+			transition: none;
+		}
+
+		.loading-spinner {
+			animation: none;
+		}
+	}
+
+	/* High performance mode */
+	@media (min-resolution: 2dppx) {
+		.fallback-image {
+			image-rendering: -webkit-optimize-contrast;
+		}
+	}
+
+	/* Dark mode support */
+	@media (prefers-color-scheme: dark) {
+		.placeholder {
+			background: #0a0a0a;
+			color: #888;
+		}
+
+		.debug-overlay {
+			background: rgba(10, 10, 10, 0.95);
+			border: 1px solid rgba(255, 255, 255, 0.1);
+		}
+	}
+
+	/* Print styles */
+	@media print {
+		.video-scrollytelling {
+			height: auto !important;
+			page-break-inside: avoid;
+		}
+
+		.debug-overlay,
+		.loading-indicator,
+		.progress-bar {
+			display: none !important;
+		}
+
+		.fallback-image {
+			position: static;
+			max-height: 400px;
+			object-fit: contain;
+		}
+
+		.steps-container {
+			position: static;
+			height: auto;
+		}
+
+		.step {
+			position: static;
+			opacity: 1 !important;
+			transform: none !important;
+			margin: 20px 0;
+		}
+	}
 </style>


### PR DESCRIPTION
## Summary
- add `forceFrames` and `frameDuration` props to VideoScrollytelling
- ensure mobile devices always use image sequence with rAF-driven frame stepping
- allow StoryRenderer to pass new frame control props

## Testing
- `npm run lint` *(fails: Unexpected token and Svelte tag errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fd58e2cc88329a750afccf839b824